### PR TITLE
Add info for homebrew-tap for modern phalcon 3.4.5

### DIFF
--- a/_layouts/download-linux.html
+++ b/_layouts/download-linux.html
@@ -79,14 +79,16 @@ sudo yum install php-devel php-mysql gcc libtool pcre-devel
 # Suse
 yast2 -i php5-pear php5-devel php5-mysql gcc libtool pcre-devel
 
-# macOS (Homebrew)
-brew tap homebrew/dupes
-brew tap homebrew/versions
-brew tap homebrew/php
-brew install php5x php5x-phalcon # php55, php56, ...
+# macOS (Homebrew) [Phalcon3.4.5 & PHP7.3]
+brew tab phalcon/extension https://github.com/ninjapanzer/homebrew-phalcon
+## For homebrew managed php version
+brew install phalcon
+## For sustem managed php version
+brew install phalcon --without-homebrew-php
 
 # macOS (MacPorts)
-sudo port install php73-phalcon # php72, php71, php56, ...</code></pre>
+sudo port install php73-phalcon # php72, php71, php56, ...
+</code></pre>
             </div>
 
             <h3>


### PR DESCRIPTION
### What am I?
Current instructions only allow for legacy php5 via homebrew but as homebrew-php tap has been deprecated these should be removed. Replaced with phalcon managed tap

### Some thoughts
My hope is we can bring this repo over to the main Phalcon org and with github action script up auto-creating PHP <-> Phalcon pairings with the pre-built assets at each release so we can have faster bottle like installs and not really have to manage this tap outside of normal homebrew breakign changes.