### PR TITLE
Update jumbo.html

### DIFF
--- a/_includes/jumbo.html
+++ b/_includes/jumbo.html
@@ -18,7 +18,7 @@
             </div>
 
             <div class="base-info__buttons">
-                <a href="/download/linux" class="green-button">
+                <a href="https://docs.phalcon.io/latest/{{ page.language }}/installation" class="green-button">
                     {{ site.data.languages[page.language]['get_phalcon'] }}
                 </a>
                 <a href="https://phalcon.io/fund" class="green-button">


### PR DESCRIPTION
Link to install page instead of linux repo. Looks like we're only supporting linux.