### PR TITLE
Updating phalcon binary location

### DIFF
--- a/_layouts/download-tools.html
+++ b/_layouts/download-tools.html
@@ -55,7 +55,7 @@ layout: default
             </p>
 
             <div class="feature__code">
-                <pre><code class="bash hljs">ln -s ~/devtools/phalcon.php /usr/bin/phalcon
+                <pre><code class="bash hljs">ln -s ~/phalcon-devtools/phalcon /usr/bin/phalcon
 chmod ugo+x /usr/bin/phalcon</code></pre>
             </div>
 


### PR DESCRIPTION
The link to phalcon binary seems to be depreciated, this is an update